### PR TITLE
Fast inference for impute based learners without the need to bootstrap for ATE confidence intervals

### DIFF
--- a/benchmark/run_dml_learner_impute.py
+++ b/benchmark/run_dml_learner_impute.py
@@ -94,7 +94,7 @@ def main(args):
                     )
 
                 learner_cls = {"causal_forest": CausalForest, "double_ml": DoubleML}[args.dml_learner]
-                learner = learner_cls()
+                learner = learner_cls(num_bootstrap_samples=args.num_bootstrap_samples)
 
                 if rand_idx in results_dict[config_name][scenario_key]:
                     # t_ = time.time()
@@ -222,6 +222,8 @@ if __name__ == "__main__":
                         choices=["Pseudo_obs", "Margin", "IPCW-T"])
     parser.add_argument("--dml_learner", type=str, default="causal_forest", 
                         choices=["double_ml", "causal_forest"])
+    parser.add_argument("--num_bootstrap_samples", type=int, default=100,
+                        help="Number of bootstrap samples for ATE inference. Set to None to disable bootstrap inference (Faste inference/Learning).")
     parser.add_argument("--save_model", action="store_true", 
                         help="If set, save the trained model. Default is False.")
     args = parser.parse_args()

--- a/benchmark/run_meta_learner_impute.py
+++ b/benchmark/run_meta_learner_impute.py
@@ -100,7 +100,7 @@ def main(args):
 
                     learner_cls = {"t_learner": T_Learner, "s_learner": S_Learner, 
                                    "x_learner": X_Learner, "dr_learner": DR_Learner}[args.meta_learner]
-                    learner = learner_cls(base_model_name=base_model)
+                    learner = learner_cls(base_model_name=base_model, num_bootstrap_samples=args.num_bootstrap_samples)
 
                     if rand_idx in results_dict[config_name][scenario_key][base_model]:
                         # t_ = time.time()
@@ -269,6 +269,8 @@ if __name__ == "__main__":
                         choices=["Pseudo_obs", "Margin", "IPCW-T"])
     parser.add_argument("--meta_learner", type=str, default="t_learner", 
                         choices=["t_learner", "s_learner", "x_learner", "dr_learner"])
+    parser.add_argument("--num_bootstrap_samples", type=int, default=100, 
+                        help="Number of bootstrap samples for ATE inference. Set to None to disable bootstrap inference (Faste inference/Learning).")
     parser.add_argument("--save_model", action="store_true", 
                         help="If set, save the trained model. Default is False.")
     args = parser.parse_args()

--- a/models_causal_impute/dml_learners.py
+++ b/models_causal_impute/dml_learners.py
@@ -7,6 +7,7 @@ from econml.inference import BootstrapInference
 import os
 import pickle
 from models_utils.checkpoint_utils import ensure_dir
+from models_utils.checkpoint_utils import AteInferenceObject
 
 class BaseDirectLearner(ABC):
     """
@@ -31,7 +32,10 @@ class BaseDirectLearner(ABC):
         cate_pred = self.predict_cate(X)
         mse = mean_squared_error(cate_true, cate_pred)
         # ate_pred = np.mean(cate_pred)
-        ate_pred = self.model.ate_inference(X)
+        if self.num_bootstrap_samples is not None and hasattr(self.model, 'ate_inference'):
+            ate_pred = self.model.ate_inference(X)
+        else:
+            ate_pred = AteInferenceObject(np.mean(cate_pred))
         return mse, cate_pred, ate_pred
     
     def save_model(self, filepath):
@@ -83,8 +87,11 @@ class DoubleML(BaseDirectLearner):
         )
 
     def fit(self, X_train, W_train, Y_train):
-        bootstap = BootstrapInference(n_bootstrap_samples=self.num_bootstrap_samples, n_jobs=1)
-        self.model.fit(Y_train, W_train, X=X_train, inference=bootstap)
+        if self.num_bootstrap_samples is not None:
+            bootstrap = BootstrapInference(n_bootstrap_samples=self.num_bootstrap_samples, n_jobs=1)
+        else:
+            bootstrap = None
+        self.model.fit(Y_train, W_train, X=X_train, inference=bootstrap)
 
     def predict_cate(self, X):
         return self.model.effect(X)
@@ -104,8 +111,11 @@ class CausalForest(BaseDirectLearner):
         )
 
     def fit(self, X_train, W_train, Y_train):
-        bootstap = BootstrapInference(n_bootstrap_samples=self.num_bootstrap_samples, n_jobs=1)
-        self.model.fit(Y_train, W_train, X=X_train, inference=bootstap)
+        if self.num_bootstrap_samples is not None:
+            bootstrap = BootstrapInference(n_bootstrap_samples=self.num_bootstrap_samples, n_jobs=1)
+        else:
+            bootstrap = None
+        self.model.fit(Y_train, W_train, X=X_train, inference=bootstrap)
 
     def predict_cate(self, X):
         return self.model.effect(X)

--- a/models_causal_impute/dml_learners.py
+++ b/models_causal_impute/dml_learners.py
@@ -76,8 +76,8 @@ class DoubleML(BaseDirectLearner):
     """
     Double Machine Learning (Partially Linear) using EconML DML.
     """
-    def __init__(self):
-        super().__init__()
+    def __init__(self, num_bootstrap_samples=100):
+        super().__init__(num_bootstrap_samples=num_bootstrap_samples)
         self.model = DML(
             model_final=StatsModelsLinearRegression(fit_intercept=False),
             model_y='auto',
@@ -101,8 +101,8 @@ class CausalForest(BaseDirectLearner):
     """
     Causal Forest using EconML's CausalForestDML.
     """
-    def __init__(self):
-        super().__init__()
+    def __init__(self, num_bootstrap_samples=100):
+        super().__init__(num_bootstrap_samples=num_bootstrap_samples)
         self.model = CausalForestDML(
             model_y='auto',
             model_t='auto',

--- a/models_causal_impute/meta_learners.py
+++ b/models_causal_impute/meta_learners.py
@@ -76,8 +76,11 @@ class BaseMetaLearner(ABC):
         - ate_pred (object): Average Treatment Effect (ATE) prediction.
         """
         cate_pred = self.predict_cate(X)
-        # ate_pred = np.mean(cate_pred)
-        ate_pred = self.model.ate_inference(X)
+        if self.num_bootstrap_sample is not None and hasattr(self.model, 'ate_inference'):
+            ate_pred = self.model.ate_inference(X)
+        else: 
+            # ate_pred = np.mean(cate_pred)
+            ate_pred = AteInferenceObject(np.mean(cate_pred))
         mse = mean_squared_error(cate_true, cate_pred)
         return mse, cate_pred, ate_pred
     
@@ -120,6 +123,18 @@ class BaseMetaLearner(ABC):
         instance.num_bootstrap_samples = model_data['num_bootstrap_samples']
         return instance
     
+class AteInferenceObject:
+    """
+    A simple wrapper for ATE inference results if no bootstrap inference is used.
+    """
+    def __init__(self, ate_value):
+        self.ate_value = ate_value
+        self.mean_point = ate_value
+        self.conf_int = (ate_value, ate_value)  # No confidence interval without bootstrap
+
+    def conf_int_mean(self):
+        return self.conf_int
+    
     
 class T_Learner(BaseMetaLearner):
     """
@@ -140,7 +155,10 @@ class T_Learner(BaseMetaLearner):
         else:
             raise ValueError(f"Unsupported model name: {self.base_model_name}")
         
-        bootstrap = BootstrapInference(n_bootstrap_samples=self.num_bootstrap_samples, n_jobs=1)
+        if self.num_bootstrap_samples is not None:
+            bootstrap = BootstrapInference(n_bootstrap_samples=self.num_bootstrap_samples, n_jobs=1)
+        else:
+            bootstrap = None
 
         self.model = TLearner(
             models=underlying_model,
@@ -184,7 +202,10 @@ class S_Learner(BaseMetaLearner):
         else:
             raise ValueError(f"Unsupported model name: {self.base_model_name}")
         
-        bootstrap = BootstrapInference(n_bootstrap_samples=self.num_bootstrap_samples, n_jobs=1)
+        if self.num_bootstrap_samples is not None:
+            bootstrap = BootstrapInference(n_bootstrap_samples=self.num_bootstrap_samples, n_jobs=1)
+        else:
+            bootstrap = None
 
         self.model = SLearner(
             overall_model=underlying_model,
@@ -228,7 +249,10 @@ class X_Learner(BaseMetaLearner):
         else:
             raise ValueError(f"Unsupported model name: {self.base_model_name}")
         
-        bootstrap = BootstrapInference(n_bootstrap_samples=self.num_bootstrap_samples, n_jobs=1)
+        if self.num_bootstrap_samples is not None:
+            bootstrap = BootstrapInference(n_bootstrap_samples=self.num_bootstrap_samples, n_jobs=1)
+        else:
+            bootstrap = None
 
         self.model = XLearner(
             models=underlying_model,
@@ -296,7 +320,11 @@ class DR_Learner(BaseMetaLearner):
             model_final=model_final,
             random_state=42,
         )
-        bootstrap = BootstrapInference(n_bootstrap_samples=self.num_bootstrap_samples, n_jobs=1)
+        if self.num_bootstrap_samples is not None:
+            bootstrap = BootstrapInference(n_bootstrap_samples=self.num_bootstrap_samples, n_jobs=1)
+        else:
+            bootstrap = None
+        
         self.model.fit(Y_train, W_train, X=X_train, inference=bootstrap)
 
     def predict_cate(self, X):

--- a/models_causal_impute/meta_learners.py
+++ b/models_causal_impute/meta_learners.py
@@ -77,7 +77,7 @@ class BaseMetaLearner(ABC):
         - ate_pred (object): Average Treatment Effect (ATE) prediction.
         """
         cate_pred = self.predict_cate(X)
-        if self.num_bootstrap_sample is not None and hasattr(self.model, 'ate_inference'):
+        if self.num_bootstrap_samples is not None and hasattr(self.model, 'ate_inference'):
             ate_pred = self.model.ate_inference(X)
         else: 
             # ate_pred = np.mean(cate_pred)

--- a/models_causal_impute/meta_learners.py
+++ b/models_causal_impute/meta_learners.py
@@ -140,12 +140,12 @@ class T_Learner(BaseMetaLearner):
         else:
             raise ValueError(f"Unsupported model name: {self.base_model_name}")
         
-        bootstap = BootstrapInference(n_bootstrap_samples=self.num_bootstrap_samples, n_jobs=1)
+        bootstrap = BootstrapInference(n_bootstrap_samples=self.num_bootstrap_samples, n_jobs=1)
 
         self.model = TLearner(
             models=underlying_model,
         )
-        self.model.fit(Y_train, W_train, X=X_train, inference=bootstap)
+        self.model.fit(Y_train, W_train, X=X_train, inference=bootstrap)
 
     def predict_cate(self, X):
         return self.model.effect(X)
@@ -184,12 +184,12 @@ class S_Learner(BaseMetaLearner):
         else:
             raise ValueError(f"Unsupported model name: {self.base_model_name}")
         
-        bootstap = BootstrapInference(n_bootstrap_samples=self.num_bootstrap_samples, n_jobs=1)
+        bootstrap = BootstrapInference(n_bootstrap_samples=self.num_bootstrap_samples, n_jobs=1)
 
         self.model = SLearner(
             overall_model=underlying_model,
         )
-        self.model.fit(Y_train, W_train, X=X_train, inference=bootstap)
+        self.model.fit(Y_train, W_train, X=X_train, inference=bootstrap)
 
     def predict_cate(self, X):
         return self.model.effect(X)
@@ -228,14 +228,14 @@ class X_Learner(BaseMetaLearner):
         else:
             raise ValueError(f"Unsupported model name: {self.base_model_name}")
         
-        bootstap = BootstrapInference(n_bootstrap_samples=self.num_bootstrap_samples, n_jobs=1)
+        bootstrap = BootstrapInference(n_bootstrap_samples=self.num_bootstrap_samples, n_jobs=1)
 
         self.model = XLearner(
             models=underlying_model,
             # propensity_model=LogisticRegression(),
             cate_models=underlying_model,
         )
-        self.model.fit(Y_train, W_train, X=X_train, inference=bootstap)
+        self.model.fit(Y_train, W_train, X=X_train, inference=bootstrap)
 
     def predict_cate(self, X):
         return self.model.effect(X)
@@ -296,8 +296,8 @@ class DR_Learner(BaseMetaLearner):
             model_final=model_final,
             random_state=42,
         )
-        bootstap = BootstrapInference(n_bootstrap_samples=self.num_bootstrap_samples, n_jobs=1)
-        self.model.fit(Y_train, W_train, X=X_train, inference=bootstap)
+        bootstrap = BootstrapInference(n_bootstrap_samples=self.num_bootstrap_samples, n_jobs=1)
+        self.model.fit(Y_train, W_train, X=X_train, inference=bootstrap)
 
     def predict_cate(self, X):
         return self.model.effect(X)

--- a/models_causal_impute/meta_learners.py
+++ b/models_causal_impute/meta_learners.py
@@ -11,6 +11,7 @@ from sklearn.linear_model import Ridge, Lasso
 from xgboost import XGBRegressor
 from .regressor_base import RegressorBaseLearner
 from models_utils.checkpoint_utils import ensure_dir
+from models_utils.checkpoint_utils import AteInferenceObject
 import pickle
 import os
 
@@ -122,18 +123,6 @@ class BaseMetaLearner(ABC):
         instance.model = model_data['model']
         instance.num_bootstrap_samples = model_data['num_bootstrap_samples']
         return instance
-    
-class AteInferenceObject:
-    """
-    A simple wrapper for ATE inference results if no bootstrap inference is used.
-    """
-    def __init__(self, ate_value):
-        self.ate_value = ate_value
-        self.mean_point = ate_value
-        self.conf_int = (ate_value, ate_value)  # No confidence interval without bootstrap
-
-    def conf_int_mean(self):
-        return self.conf_int
     
     
 class T_Learner(BaseMetaLearner):

--- a/models_utils/checkpoint_utils.py
+++ b/models_utils/checkpoint_utils.py
@@ -28,3 +28,16 @@ def get_checkpoint_path(dataset_type, causal_config, scenario, model_family,
     ensure_dir(base_path)
     filename = f"{model_name}_repeat{repeat_idx}.pkl"
     return os.path.join(base_path, filename)
+
+
+class AteInferenceObject:
+    """
+    A simple wrapper for ATE inference results if no bootstrap inference is used.
+    """
+    def __init__(self, ate_value):
+        self.ate_value = ate_value
+        self.mean_point = ate_value
+        self.conf_int = (ate_value, ate_value)  # No confidence interval without bootstrap
+
+    def conf_int_mean(self):
+        return self.conf_int


### PR DESCRIPTION
Enable fast inference without bootstrapping (point-estimate mode) for impute based methods (`meta_learners` and  `dml_learners`).

---

## Summary  

This PR introduces the ability to run inference without bootstrapping to support faster execution when confidence intervals are not required.

When `num_bootstrap_samples` is set to `None`, the code now:

- Skips the bootstrap procedure entirely
- Returns a point estimate for the predicted ATE instead of a confidence interval
- Preserves backward compatibility with existing result interfaces

Importantly, this change **does not affect CATE estimation**.

---

## What Changed  

### 1. Fast Inference Mode  
- If `num_bootstrap_samples=None`, no bootstrap samples are generated.
- The predicted ATE is returned as a point estimate.

### 2. Backward Compatibility  

To ensure compatibility with previous runs and downstream code:

- The result still exposes a `mean_point` field.
- Calling `conf_int_mean()` returns a tuple where both bounds equal the mean predicted CATE:

## Behavior Summary  

| Setting | Behavior |
|----------|----------|
| `num_bootstrap_samples (default=100) > 0` | Standard bootstrap + confidence interval for ATE |
| `num_bootstrap_samples = None` | No bootstrap, point estimate only (faster) |